### PR TITLE
Issue #1: Add issue templates

### DIFF
--- a/.github/BUG-REPORT.yml
+++ b/.github/BUG-REPORT.yml
@@ -1,0 +1,72 @@
+name: "🐛 Bug Report"
+description: Report a bug.
+title: "🐛 [BUG] - <title>"
+labels: [
+  "bug"
+]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: Please enter an explicit description of the issue
+      placeholder: Short and explicit description of the incident...
+    validations:
+      required: true
+  - type: textarea
+    id: reprod
+    attributes:
+      label: "Reproduction steps"
+      description: Please enter an explicit description of your issue
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+      render: bash
+    validations:
+      required: true
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: "Screenshots"
+      description: If applicable, add screenshots/videos to help explain your problem.
+      value: |
+        ![DESCRIPTION](LINK.png)
+      render: bash
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Logs"
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: bash
+    validations:
+      required: false
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: "Browsers"
+      description: What browsers are you seeing the problem on ?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Other
+    validations:
+      required: false
+  - type: dropdown
+    id: os
+    attributes:
+      label: "OS"
+      description: What is the impacted environment ?
+      multiple: true
+      options:
+        - Windows
+        - Linux
+        - Mac
+    validations:
+      required: false

--- a/.github/FEATURE-REQUEST.yml
+++ b/.github/FEATURE-REQUEST.yml
@@ -1,0 +1,39 @@
+name: "💡 Feature Request"
+description: Create a new feature request
+title: "💡 [REQUEST] - <title>"
+labels: [
+  "enhancement"
+]
+body:
+  - type: textarea
+    id: implementation_pr
+    attributes:
+      label: "Implementation PR"
+      description: If you have a PR that implements this feature list it below
+      placeholder: "#PullRequestID"
+    validations:
+      required: false
+  - type: textarea
+    id: reference_issues
+    attributes:
+      label: "Reference Issue(s)"
+      description: List the issue(s) that are related to this feature request
+      placeholder: "Closes #IssueID"
+    validations:
+      required: false
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Summary"
+      description: Provide a brief explanation of the feature
+      placeholder: Describe in a few lines your feature request
+    validations:
+      required: true
+  - type: textarea
+    id: unresolved_question
+    attributes:
+      label: "Unresolved questions"
+      description: What questions still remain unresolved ?
+      placeholder: Identify any unresolved issues.
+    validations:
+      required: false

--- a/.github/SECURITY_REPORT.yml
+++ b/.github/SECURITY_REPORT.yml
@@ -1,0 +1,60 @@
+name: "⚠️ Security Vulnerability Report"
+description: File a security vulnerability report
+title: "⚠️ [Security] - <title> "
+labels: ["security"]
+assignees:
+  - pi0neerpat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this security vulnerability report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: e.g., email@example.com
+    validations:
+      required: true
+  - type: textarea
+    id: whats-wrong
+    attributes:
+      label: Describe the vulnerability
+      description: A clear and concise description of what the vulnerability is.
+      placeholder: What's wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem.
+      placeholder: |
+        ![DESCRIPTION](LINK.png)
+    validations:
+      required: false
+  - type: dropdown
+    id: devices-affected
+    attributes:
+      label: What devices does this affect?
+      multiple: true
+      options:
+        - All
+        - Windows
+        - macOS
+        - Linux
+        - Android
+        - iOS
+        - Other
+  - type: dropdown
+    id: browsers-affected
+    attributes:
+      label: What browsers does this affect?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Other

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Closes #1 

### Description
- These are templates for creating a bug report, feature request, and reporting a security vulnerability.

This is using [GitHub's issue forms schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms). Let me know if you think there are an fields that are missing/that could be cut out

### Screenshots
When someone goes to make an issue it will look more or less like this: 

<img width="682" alt="Screenshot 2022-12-22 at 2 30 19 PM" src="https://user-images.githubusercontent.com/47253537/209212024-a9b26f25-fd7a-420d-8f78-4668bb70ab9e.png">

### Checklist

- [X] Fix all lint + build issues with CI
- [X] Request a review